### PR TITLE
Update DMRLC.cpp

### DIFF
--- a/DMRLC.cpp
+++ b/DMRLC.cpp
@@ -25,6 +25,7 @@
 
 #include "Utils.h"
 
+#include <cstring>
 #include <cstdio>
 #include <cassert>
 


### PR DESCRIPTION
Fixing the error "‘::memset’ has not been declared" / "‘::memcpy’ has not been declared"